### PR TITLE
Revamp CI workflow with linting and Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,19 @@ on:
   pull_request:
     branches: [ main, master ]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  lint_type_test:
+    name: Lint, Type Check, Test
     runs-on: ubuntu-latest
     env:
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      PIP_NO_PYTHON_VERSION_WARNING: "1"
+      PYTHONDONTWRITEBYTECODE: "1"
+      PYTHONUNBUFFERED: "1"
       CPS_OFFLINE: "1"
     steps:
       - name: Checkout
@@ -19,8 +28,62 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
 
-      - name: Install and test
+      - name: Install dependencies
         run: |
-          make setup
-          make test
+          python -m pip install -U pip
+          python -m pip install -e ".[dev]"
+
+      - name: Ruff
+        run: ruff check src tests
+
+      - name: Black (check)
+        run: black --check src tests
+
+      - name: Mypy
+        run: mypy src tests
+
+      - name: Pytest
+        run: pytest -q
+
+  docker:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    needs: lint_type_test
+    if: ${{ needs.lint_type_test.result == 'success' }}
+    permissions:
+      contents: read
+      packages: read
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (load to Docker)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: true
+          tags: catalog-pii-scanner:ci-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Save image as artifact
+        run: |
+          docker save catalog-pii-scanner:ci-${{ github.sha }} -o /tmp/catalog-pii-scanner-${{ github.sha }}.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: catalog-pii-scanner-image-${{ github.sha }}
+          path: /tmp/catalog-pii-scanner-${{ github.sha }}.tar
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
Splits CI into separate lint/type/test and Docker build jobs. Adds concurrency control, caching for pip, and explicit steps for Ruff, Black, Mypy, and Pytest. Docker image is built only if tests pass and is saved as an artifact.