### PR TITLE
Add AWS Glue Data Catalog connector and CLI integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "pydantic>=2.7.0",
   "PyYAML>=6.0.0",
   "SQLAlchemy>=2.0.30",
+  "boto3>=1.34.0",
 ]
 
 [project.optional-dependencies]

--- a/src/catalog_pii_scanner/connectors/__init__.py
+++ b/src/catalog_pii_scanner/connectors/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__all__ = ["glue"]

--- a/src/catalog_pii_scanner/connectors/glue.py
+++ b/src/catalog_pii_scanner/connectors/glue.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import copy
+import os
+import random
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any, cast
+
+try:
+    import boto3  # type: ignore
+    from botocore.exceptions import ClientError  # type: ignore
+except Exception:  # pragma: no cover - optional dependency in some envs
+    boto3 = None  # type: ignore
+    ClientError = Exception  # type: ignore
+
+
+# --------- Retry / backoff helpers ---------
+
+
+def _is_throttle_error(err: Exception) -> bool:
+    try:
+        if isinstance(err, ClientError):  # type: ignore[misc]
+            code = err.response.get("Error", {}).get("Code")
+            return code in {
+                "ThrottlingException",
+                "TooManyRequestsException",
+                "RequestLimitExceeded",
+            }
+    except Exception:  # pragma: no cover - defensive
+        return False
+    return False
+
+
+def _with_retries(fn: Callable[[], Any], *, max_retries: int = 5, base_delay: float = 0.5) -> Any:
+    """Call `fn` with exponential backoff on throttling-like errors."""
+    attempt = 0
+    while True:
+        try:
+            return fn()
+        except Exception as e:  # noqa: BLE001
+            if attempt >= max_retries or not _is_throttle_error(e):
+                raise
+            # Exponential backoff with jitter
+            delay = base_delay * (2**attempt) * (0.5 + random.random())
+            time.sleep(min(delay, 8.0))
+            attempt += 1
+
+
+# --------- Data structures ---------
+
+
+@dataclass
+class GlueColumn:
+    database: str
+    table: str
+    name: str
+    type: str | None
+    comment: str | None
+    parameters: dict[str, str]
+
+    @property
+    def ref(self) -> str:
+        return f"glue://{self.database}/{self.table}/{self.name}"
+
+
+# --------- Client wrapper ---------
+
+
+class GlueCatalogClient:
+    """Thin wrapper over boto3 Glue client with safe defaults and retries."""
+
+    def __init__(
+        self,
+        *,
+        region_name: str | None = None,
+        endpoint_url: str | None = None,
+        boto3_client: Any | None = None,
+        max_retries: int = 5,
+        base_delay: float = 0.5,
+    ) -> None:
+        if boto3_client is not None:
+            self._client = boto3_client
+        else:
+            if boto3 is None:
+                raise RuntimeError("boto3 is required for GlueCatalogClient but is not installed")
+            # Allow overriding via env (useful for Localstack)
+            region_name = region_name or os.getenv("AWS_REGION") or "us-east-1"
+            endpoint_url = (
+                endpoint_url or os.getenv("AWS_ENDPOINT_URL") or os.getenv("GLUE_ENDPOINT_URL")
+            )
+            self._client = boto3.client("glue", region_name=region_name, endpoint_url=endpoint_url)
+
+        self._max_retries = max_retries
+        self._base_delay = base_delay
+
+    # ----- Enumeration -----
+
+    def list_databases(self) -> list[str]:
+        next_token: str | None = None
+        names: list[str] = []
+        while True:
+
+            def _call(token: str | None = next_token) -> dict[str, Any]:  # bind loop var
+                if token:
+                    return cast(dict[str, Any], self._client.get_databases(NextToken=token))
+                return cast(dict[str, Any], self._client.get_databases())
+
+            resp = cast(
+                dict[str, Any],
+                _with_retries(_call, max_retries=self._max_retries, base_delay=self._base_delay),
+            )
+            for db in resp.get("DatabaseList", []) or []:
+                if db.get("Name"):
+                    names.append(db["Name"])  # type: ignore[index]
+            next_token = resp.get("NextToken")
+            if not next_token:
+                break
+        return names
+
+    def list_tables(self, database: str) -> list[dict[str, Any]]:
+        next_token: str | None = None
+        out: list[dict[str, Any]] = []
+        while True:
+
+            def _call(token: str | None = next_token) -> dict[str, Any]:  # bind loop var
+                if token:
+                    return cast(
+                        dict[str, Any],
+                        self._client.get_tables(DatabaseName=database, NextToken=token),
+                    )
+                return cast(dict[str, Any], self._client.get_tables(DatabaseName=database))
+
+            resp = _with_retries(_call, max_retries=self._max_retries, base_delay=self._base_delay)
+            out.extend(resp.get("TableList", []) or [])
+            next_token = resp.get("NextToken")
+            if not next_token:
+                break
+        return out
+
+    def iter_columns(
+        self,
+        db_patterns: Iterable[str] | None = None,
+        table_patterns: Iterable[str] | None = None,
+    ) -> Iterable[GlueColumn]:
+        import fnmatch
+
+        db_pats = list(db_patterns or ["*"])
+        tbl_pats = list(table_patterns or ["*"])
+
+        for db in self.list_databases():
+            if not any(fnmatch.fnmatch(db, p) for p in db_pats):
+                continue
+            for tbl in self.list_tables(db):
+                name = tbl.get("Name")
+                if not name:
+                    continue
+                if not any(fnmatch.fnmatch(name, p) for p in tbl_pats):
+                    continue
+                sd = tbl.get("StorageDescriptor") or {}
+                cols = sd.get("Columns") or []
+                for c in cols:
+                    yield GlueColumn(
+                        database=db,
+                        table=name,  # type: ignore[arg-type]
+                        name=c.get("Name"),  # type: ignore[arg-type]
+                        type=c.get("Type"),  # type: ignore[arg-type]
+                        comment=c.get("Comment"),  # type: ignore[arg-type]
+                        parameters=c.get("Parameters") or {},
+                    )
+
+    # ----- Writeback (idempotent) -----
+
+    def get_table(self, database: str, table: str) -> dict[str, Any]:
+        def _call() -> dict[str, Any]:
+            return cast(dict[str, Any], self._client.get_table(DatabaseName=database, Name=table))
+
+        return cast(
+            dict[str, Any],
+            _with_retries(_call, max_retries=self._max_retries, base_delay=self._base_delay),
+        )
+
+    def update_column_tags(
+        self,
+        *,
+        database: str,
+        table: str,
+        column: str,
+        pii: bool,
+        pii_types: list[str] | None = None,
+        append_comment: str | None = None,
+    ) -> bool:
+        """Update column parameters and optionally append comment.
+
+        Returns True if an update was applied; False if no changes needed.
+        """
+        tbl: dict[str, Any] = self.get_table(database, table).get("Table", {})
+        tbl_input = _table_to_input(tbl)
+
+        sd = tbl_input.get("StorageDescriptor") or {}
+        cols = sd.get("Columns") or []
+        changed = False
+        for c in cols:
+            if c.get("Name") != column:
+                continue
+            params = c.get("Parameters") or {}
+            new_params = dict(params)
+            # idempotent parameter updates
+            if str(new_params.get("pii")).lower() != str(bool(pii)).lower():
+                new_params["pii"] = str(bool(pii)).lower()
+            if pii_types is not None:
+                desired_list = [t.strip() for t in pii_types if t.strip()]
+                desired = ",".join(sorted(desired_list))
+                if new_params.get("pii_types") != desired:
+                    new_params["pii_types"] = desired
+            if new_params != params:
+                c["Parameters"] = new_params
+                changed = True
+
+            if append_comment:
+                existing: str = c.get("Comment") or ""
+                if append_comment not in (existing or ""):
+                    c["Comment"] = (existing + (" " if existing else "") + append_comment)[:255]
+                    changed = True
+            break
+
+        if not changed:
+            return False
+
+        def _call() -> Any:
+            return self._client.update_table(DatabaseName=database, TableInput=tbl_input)
+
+        _with_retries(_call, max_retries=self._max_retries, base_delay=self._base_delay)
+        return True
+
+
+# --------- Helpers ---------
+
+
+def _table_to_input(tbl: dict[str, Any]) -> dict[str, Any]:
+    """Convert Glue GetTable output to a valid TableInput for UpdateTable.
+
+    Drops read-only fields.
+    """
+    drop_keys = {
+        "DatabaseName",
+        "CreateTime",
+        "UpdateTime",
+        "CreatedBy",
+        "IsRegisteredWithLakeFormation",
+        "CatalogId",
+        "VersionId",
+        "FederatedTable",
+    }
+    ti = {k: v for k, v in tbl.items() if k not in drop_keys}
+    # Deep-copy and drop sub-keys if present
+    ti = copy.deepcopy(ti)
+    # Ensure required fields exist minimally
+    ti.setdefault("Name", tbl.get("Name"))
+    ti.setdefault("StorageDescriptor", tbl.get("StorageDescriptor") or {})
+    ti.setdefault("Parameters", tbl.get("Parameters") or {})
+    ti.setdefault("TableType", tbl.get("TableType") or "EXTERNAL_TABLE")
+    return ti
+
+
+__all__ = [
+    "GlueCatalogClient",
+    "GlueColumn",
+]

--- a/tests/test_glue_backoff.py
+++ b/tests/test_glue_backoff.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from catalog_pii_scanner.connectors.glue import GlueCatalogClient
+
+try:
+    from botocore.exceptions import ClientError  # type: ignore
+except Exception:  # pragma: no cover - environment without boto3
+    ClientError = Exception  # type: ignore
+
+
+class _FlakyGlue:
+    def __init__(self, fail_times: int) -> None:
+        self.calls = 0
+        self.fail_times = fail_times
+
+    def get_databases(self, **_: Any) -> dict:
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise ClientError(
+                {"Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}},
+                "GetDatabases",
+            )
+        return {"DatabaseList": [{"Name": "demo"}]}
+
+
+def test_backoff_succeeds_after_throttle_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Skip if boto3 not available in env
+    try:
+        import boto3  # type: ignore  # noqa: F401
+    except Exception:
+        pytest.skip("boto3 not installed in this env")
+
+    flaky = _FlakyGlue(fail_times=2)
+    cli = GlueCatalogClient(boto3_client=flaky, max_retries=3, base_delay=0.01)
+    dbs = cli.list_databases()
+    assert dbs == ["demo"]

--- a/tests/test_glue_localstack.py
+++ b/tests/test_glue_localstack.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import os
+import socket
+from urllib.parse import urlparse
+
+import pytest
+from typer.testing import CliRunner
+
+from catalog_pii_scanner.cli import app
+
+
+def _has_localstack() -> bool:
+    # Check that the endpoint is reachable on TCP
+    url = os.getenv("AWS_ENDPOINT_URL") or os.getenv("GLUE_ENDPOINT_URL") or "http://localhost:4566"
+    try:
+        p = urlparse(url)
+        host = p.hostname or "localhost"
+        port = p.port or (443 if p.scheme == "https" else 80)
+        with socket.create_connection((host, port), timeout=0.2):
+            return True
+    except Exception:
+        return False
+
+
+def test_glue_enumerate_and_writeback_localstack(monkeypatch: pytest.MonkeyPatch) -> None:
+    if not _has_localstack():
+        pytest.skip("Localstack endpoint not configured")
+
+    try:
+        import boto3  # type: ignore
+    except Exception:
+        pytest.skip("boto3 not installed in this env")
+
+    endpoint = os.getenv("AWS_ENDPOINT_URL", "http://localhost:4566")
+    region = os.getenv("AWS_REGION", "us-east-1")
+    # Minimal creds for localstack
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", os.getenv("AWS_ACCESS_KEY_ID", "test"))
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", os.getenv("AWS_SECRET_ACCESS_KEY", "test"))
+    monkeypatch.setenv("AWS_REGION", region)
+    monkeypatch.setenv("AWS_ENDPOINT_URL", endpoint)
+
+    glue = boto3.client("glue", region_name=region, endpoint_url=endpoint)
+
+    # Create demo catalog if not exists
+    db_name = "demo"
+    try:
+        glue.create_database(DatabaseInput={"Name": db_name})
+    except Exception:
+        pass
+
+    tbl_name = "users"
+    cols = [
+        {"Name": "id", "Type": "int"},
+        {"Name": "email", "Type": "string", "Comment": "user email"},
+        {"Name": "age", "Type": "int"},
+    ]
+    try:
+        glue.create_table(
+            DatabaseName=db_name,
+            TableInput={
+                "Name": tbl_name,
+                "StorageDescriptor": {
+                    "Columns": cols,
+                    "Location": "s3://dummy",
+                },
+                "TableType": "EXTERNAL_TABLE",
+                "Parameters": {},
+            },
+        )
+    except Exception:
+        pass
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            "--target",
+            "glue://*",
+            "--apply",
+            "--type",
+            "EMAIL",
+            "--append-comment",
+            "PII detected",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data["count"] >= 1
+
+    # Verify writeback on the email column
+    t = glue.get_table(DatabaseName=db_name, Name=tbl_name)["Table"]
+    c = next(cc for cc in t["StorageDescriptor"]["Columns"] if cc["Name"] == "email")
+    params = c.get("Parameters") or {}
+    assert params.get("pii") == "true"
+    assert params.get("pii_types") == "EMAIL"
+    assert "PII detected" in (c.get("Comment") or "")
+
+    # Idempotent: run again and ensure comment not duplicated
+    result2 = runner.invoke(
+        app,
+        [
+            "scan",
+            "--target",
+            "glue://*",
+            "--apply",
+            "--type",
+            "EMAIL",
+            "--append-comment",
+            "PII detected",
+        ],
+    )
+    assert result2.exit_code == 0
+    t2 = glue.get_table(DatabaseName=db_name, Name=tbl_name)["Table"]
+    c2 = next(cc for cc in t2["StorageDescriptor"]["Columns"] if cc["Name"] == "email")
+    assert (c2.get("Comment") or "").count("PII detected") == 1


### PR DESCRIPTION
Introduces a GlueCatalogClient for enumerating and tagging columns in AWS Glue Data Catalog. Updates CLI to support scanning and applying tags/comments to Glue columns via a new --target option. Adds boto3 as a dependency and includes tests for backoff logic and Localstack integration.