### PR TITLE
Add Hive Metastore (HMS) connector and CLI support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dev = [
   "mypy>=1.10.0",
   "httpx>=0.27.0",
   "types-requests>=2.32.0.20240622",
+  "testcontainers>=3.7.1",
+  "hmsclient>=0.1.1",
 ]
 ml = [
   "sentence-transformers>=2.5.1",

--- a/src/catalog_pii_scanner/connectors/__init__.py
+++ b/src/catalog_pii_scanner/connectors/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__all__ = ["glue", "unity"]
+__all__ = ["glue", "unity", "hms"]

--- a/src/catalog_pii_scanner/connectors/hms.py
+++ b/src/catalog_pii_scanner/connectors/hms.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import fnmatch
+import os
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from typing import Any, cast
+
+try:  # Optional dependency; tests may mock
+    from hmsclient import hmsclient as _hms
+    from hmsclient.genthrift.hive_metastore import ttypes as _ttypes
+except Exception:  # pragma: no cover - optional dependency guard
+    _hms = None  # type: ignore
+    _ttypes = None  # type: ignore
+
+
+@dataclass
+class HMSColumn:
+    database: str
+    table: str
+    name: str
+    type: str | None
+    comment: str | None
+    properties: dict[str, str]
+
+    @property
+    def ref(self) -> str:
+        return f"hms://{self.database}/{self.table}/{self.name}"
+
+
+class HiveMetastoreClient:
+    """Hive Metastore (Thrift) client wrapper.
+
+    - Enumerates columns via Thrift `get_table`
+    - Writes back by altering table column comments and table parameters
+
+    Env defaults:
+      - `HMS_HOST` (default: localhost)
+      - `HMS_PORT` (default: 9083)
+    """
+
+    def __init__(
+        self,
+        *,
+        host: str | None = None,
+        port: int | None = None,
+        raw_client: Any | None = None,
+    ) -> None:
+        if raw_client is not None:
+            self._client = raw_client
+        else:
+            if _hms is None:  # pragma: no cover - import guard
+                raise RuntimeError(
+                    "hmsclient is required for HiveMetastoreClient but is not installed"
+                )
+            host = host or os.getenv("HMS_HOST") or "localhost"
+            port = int(port or int(os.getenv("HMS_PORT", "9083")))
+            # hmsclient is a context manager; open a long-lived connection
+            cli = _hms.HMSClient(host=host, port=port)
+            cli.open()
+            self._client = cli
+
+    # ------------- Enumeration -------------
+
+    def list_databases(self) -> list[str]:
+        dbs = cast(list[str], self._client.get_all_databases())
+        return sorted(dbs)
+
+    def list_tables(self, database: str) -> list[str]:
+        tbls = cast(list[str], self._client.get_all_tables(database))
+        return sorted(tbls)
+
+    def get_table(self, database: str, table: str) -> Any:
+        return self._client.get_table(database, table)
+
+    def iter_columns(
+        self,
+        db_patterns: Iterable[str] | None = None,
+        table_patterns: Iterable[str] | None = None,
+    ) -> Iterator[HMSColumn]:
+        db_pats = list(db_patterns or ["*"])
+        tbl_pats = list(table_patterns or ["*"])
+        for db in self.list_databases():
+            if not any(fnmatch.fnmatch(db, p) for p in db_pats):
+                continue
+            for tname in self.list_tables(db):
+                if not any(fnmatch.fnmatch(tname, p) for p in tbl_pats):
+                    continue
+                t = self.get_table(db, tname)
+                sd = getattr(t, "sd", None)
+                cols = getattr(sd, "cols", []) or []
+                props = cast(dict[str, str], getattr(t, "parameters", {}) or {})
+                for c in cols:
+                    name = getattr(c, "name", None)
+                    dtype = getattr(c, "type", None)
+                    comment = getattr(c, "comment", None)
+                    if not name:
+                        continue
+                    yield HMSColumn(
+                        database=db,
+                        table=tname,
+                        name=name,
+                        type=dtype,
+                        comment=comment,
+                        properties=props,
+                    )
+
+    # ------------- Writeback -------------
+
+    def update_column_tags(
+        self,
+        *,
+        database: str,
+        table: str,
+        column: str,
+        pii: bool,
+        pii_types: list[str] | None = None,
+        append_comment: str | None = None,
+    ) -> bool:
+        """Idempotently update table parameters and column comment via alter_table.
+
+        Returns True if any change was applied.
+        """
+        t = self.get_table(database, table)
+        changed = False
+
+        # Update table-level parameters to reflect column tagging
+        params = cast(dict[str, str], getattr(t, "parameters", {}) or {})
+        new_params = dict(params)
+        key_enabled = f"cps.pii.col.{column}"
+        if str(new_params.get(key_enabled)).lower() != str(bool(pii)).lower():
+            new_params[key_enabled] = str(bool(pii)).lower()
+            changed = True
+        if pii_types is not None:
+            desired = ",".join(sorted(t.strip() for t in pii_types if t.strip()))
+            key_types = f"cps.pii_types.col.{column}"
+            if new_params.get(key_types) != desired:
+                new_params[key_types] = desired
+                changed = True
+        if new_params != params:
+            t.parameters = new_params  # type: ignore[attr-defined]
+
+        # Update column comment if needed
+        sd = getattr(t, "sd", None)
+        cols = getattr(sd, "cols", []) or []
+        for c in cols:
+            if getattr(c, "name", None) != column:
+                continue
+            if append_comment:
+                existing = cast(str, getattr(c, "comment", None) or "")
+                if append_comment not in existing:
+                    new_comment = (existing + (" " if existing else "") + append_comment)[:255]
+                    c.comment = new_comment  # type: ignore[attr-defined]
+                    changed = True
+            break
+
+        if not changed:
+            return False
+
+        # Apply via alter_table
+        self._client.alter_table(database, table, t)
+        return True
+
+
+__all__ = [
+    "HiveMetastoreClient",
+    "HMSColumn",
+]

--- a/tests/test_hms_fake.py
+++ b/tests/test_hms_fake.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from time import time
+from typing import Any, cast
+
+import pytest
+from typer.testing import CliRunner
+
+from catalog_pii_scanner.cli import app
+
+try:
+    from hmsclient.genthrift.hive_metastore import ttypes  # type: ignore
+
+    from catalog_pii_scanner.connectors.hms import HiveMetastoreClient
+except Exception:  # pragma: no cover - optional dependency not installed
+    ttypes = None  # type: ignore
+    HiveMetastoreClient = None  # type: ignore
+
+
+pytestmark = pytest.mark.skipif(ttypes is None, reason="hmsclient not installed")
+
+
+class _FakeHMS:
+    def __init__(self) -> None:
+        self._dbs: dict[str, dict[str, Any]] = {}
+
+    # Minimal API used by HiveMetastoreClient
+    def get_all_databases(self) -> list[str]:
+        return list(self._dbs.keys())
+
+    def get_all_tables(self, db: str) -> list[str]:
+        return list(self._dbs.get(db, {}))
+
+    def get_table(self, db: str, name: str) -> Any:
+        return cast(Any, self._dbs[db][name])
+
+    def alter_table(self, db: str, name: str, new_table: Any) -> None:
+        self._dbs.setdefault(db, {})[name] = new_table
+
+    # Helpers for setup
+    def create_database(self, name: str) -> None:
+        self._dbs.setdefault(name, {})
+
+    def create_simple_table(self, db: str, name: str) -> None:
+        cols = [
+            ttypes.FieldSchema(name="id", type="int", comment=None),  # type: ignore[attr-defined]
+            ttypes.FieldSchema(name="email", type="string", comment="user email"),  # type: ignore[attr-defined]
+        ]
+        sdi = ttypes.SerDeInfo(  # type: ignore[attr-defined]
+            name="serde",
+            serializationLib="org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+            parameters={},
+        )
+        sd = ttypes.StorageDescriptor(  # type: ignore[attr-defined]
+            cols=cols,
+            location="file:/tmp",
+            inputFormat="org.apache.hadoop.mapred.TextInputFormat",
+            outputFormat="org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+            compressed=False,
+            numBuckets=0,
+            serdeInfo=sdi,
+            bucketCols=[],
+            sortCols=[],
+            parameters={},
+            skewedInfo=None,
+            storedAsSubDirectories=False,
+        )
+        tbl = ttypes.Table(  # type: ignore[attr-defined]
+            tableName=name,
+            dbName=db,
+            owner="owner",
+            createTime=int(time()),
+            lastAccessTime=0,
+            retention=0,
+            sd=sd,
+            partitionKeys=[],
+            parameters={},
+            tableType="EXTERNAL_TABLE",
+        )
+        self._dbs.setdefault(db, {})[name] = tbl
+
+
+def test_hms_enumerate_and_writeback_fake(monkeypatch: Any) -> None:
+    fake = _FakeHMS()
+    fake.create_database("demo")
+    fake.create_simple_table("demo", "users")
+
+    # Patch CLI to use our client
+    client = HiveMetastoreClient(raw_client=fake)  # type: ignore[arg-type]
+    monkeypatch.setattr(
+        "catalog_pii_scanner.cli.HiveMetastoreClient",
+        lambda: client,
+        raising=True,
+    )
+
+    runner = CliRunner()
+    res = runner.invoke(
+        app,
+        [
+            "scan",
+            "--target",
+            "hms://*",
+            "--apply",
+            "--type",
+            "EMAIL",
+            "--append-comment",
+            "PII detected",
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.stdout)
+    assert payload["count"] >= 1
+
+    # Verify writeback idempotency and properties
+    tbl = fake.get_table("demo", "users")
+    props = getattr(tbl, "parameters", {})
+    assert props.get("cps.pii.col.email") == "true"
+    assert props.get("cps.pii_types.col.email") == "EMAIL"
+    col = next(c for c in getattr(tbl.sd, "cols", []) if c.name == "email")
+    assert "PII detected" in (col.comment or "")
+
+    # Run again; comment should not duplicate
+    res2 = runner.invoke(
+        app,
+        [
+            "scan",
+            "--target",
+            "hms://*",
+            "--apply",
+            "--type",
+            "EMAIL",
+            "--append-comment",
+            "PII detected",
+        ],
+    )
+    assert res2.exit_code == 0
+    tbl2 = fake.get_table("demo", "users")
+    col2 = next(c for c in getattr(tbl2.sd, "cols", []) if c.name == "email")
+    assert (col2.comment or "").count("PII detected") == 1

--- a/tests/test_hms_testcontainers.py
+++ b/tests/test_hms_testcontainers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import socket
 import time
 from typing import Any
@@ -97,7 +98,7 @@ def test_hms_enumerate_and_writeback_with_container(monkeypatch: Any) -> None:
             except Exception:
                 pass
 
-        # Run CLI scan against HMS and apply tags
+        # Run CLI scan against HMS and apply tags (pass host/port via env)
         runner = CliRunner()
         res = runner.invoke(
             app,
@@ -111,6 +112,11 @@ def test_hms_enumerate_and_writeback_with_container(monkeypatch: Any) -> None:
                 "--append-comment",
                 "PII detected",
             ],
+            env={
+                **os.environ,
+                "HMS_HOST": "127.0.0.1",
+                "HMS_PORT": str(port),
+            },
         )
         assert res.exit_code == 0, res.output
         data = json.loads(res.stdout)
@@ -138,6 +144,11 @@ def test_hms_enumerate_and_writeback_with_container(monkeypatch: Any) -> None:
                 "--append-comment",
                 "PII detected",
             ],
+            env={
+                **os.environ,
+                "HMS_HOST": "127.0.0.1",
+                "HMS_PORT": str(port),
+            },
         )
         assert res2.exit_code == 0
         with hmsclient.HMSClient(host="127.0.0.1", port=port) as cli:  # type: ignore[misc]

--- a/tests/test_hms_testcontainers.py
+++ b/tests/test_hms_testcontainers.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import socket
+import time
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from catalog_pii_scanner.cli import app
+
+try:  # Optional runtime deps for this test
+    from hmsclient import hmsclient  # type: ignore
+    from hmsclient.genthrift.hive_metastore import ttypes  # type: ignore
+    from testcontainers.core.container import DockerContainer  # type: ignore
+except Exception:  # pragma: no cover - optional dependency not installed
+    DockerContainer = None  # type: ignore
+    hmsclient = None  # type: ignore
+    ttypes = None  # type: ignore
+
+
+pytestmark = pytest.mark.skipif(
+    any(x is None for x in [DockerContainer, hmsclient, ttypes]),
+    reason="testcontainers/hmsclient not installed",
+)
+
+
+def _wait_port(host: str, port: int, timeout: float = 30.0) -> None:
+    deadline = time.time() + timeout
+    last_err: Exception | None = None
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return
+        except Exception as e:  # noqa: BLE001
+            last_err = e
+            time.sleep(0.5)
+    if last_err:
+        raise last_err
+
+
+def test_hms_enumerate_and_writeback_with_container(monkeypatch: Any) -> None:
+    # Use Iceberg's lightweight HMS image (derby-backed)
+    with DockerContainer("tabulario/hive-metastore:3.1.2").with_exposed_ports(9083) as c:  # type: ignore[operator]
+        port = int(c.get_exposed_port(9083))  # type: ignore[arg-type]
+        _wait_port("127.0.0.1", port, timeout=60.0)
+
+        # Create demo DB and table via Thrift
+        with hmsclient.HMSClient(host="127.0.0.1", port=port) as cli:  # type: ignore[misc]
+            try:
+                cli.create_database(  # type: ignore[attr-defined]
+                    ttypes.Database(name="demo", description=None, locationUri=None, parameters={})  # type: ignore[attr-defined]
+                )
+            except Exception:
+                pass
+
+            cols = [
+                ttypes.FieldSchema(name="id", type="int", comment=None),  # type: ignore[attr-defined]
+                ttypes.FieldSchema(name="email", type="string", comment="user email"),  # type: ignore[attr-defined]
+            ]
+            sdi = ttypes.SerDeInfo(  # type: ignore[attr-defined]
+                name="serde",
+                serializationLib="org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+                parameters={},
+            )
+            sd = ttypes.StorageDescriptor(  # type: ignore[attr-defined]
+                cols=cols,
+                location="file:/tmp",
+                inputFormat="org.apache.hadoop.mapred.TextInputFormat",
+                outputFormat="org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                compressed=False,
+                numBuckets=0,
+                serdeInfo=sdi,
+                bucketCols=[],
+                sortCols=[],
+                parameters={},
+                skewedInfo=None,
+                storedAsSubDirectories=False,
+            )
+            from time import time as _now
+
+            tbl = ttypes.Table(  # type: ignore[attr-defined]
+                tableName="users",
+                dbName="demo",
+                owner="owner",
+                createTime=int(_now()),
+                lastAccessTime=0,
+                retention=0,
+                sd=sd,
+                partitionKeys=[],
+                parameters={},
+                tableType="EXTERNAL_TABLE",
+            )
+            try:
+                cli.create_table(tbl)  # type: ignore[attr-defined]
+            except Exception:
+                pass
+
+        # Run CLI scan against HMS and apply tags
+        runner = CliRunner()
+        res = runner.invoke(
+            app,
+            [
+                "scan",
+                "--target",
+                "hms://*",
+                "--apply",
+                "--type",
+                "EMAIL",
+                "--append-comment",
+                "PII detected",
+            ],
+        )
+        assert res.exit_code == 0, res.output
+        data = json.loads(res.stdout)
+        assert data["count"] >= 1
+
+        # Verify writeback: properties + comment
+        with hmsclient.HMSClient(host="127.0.0.1", port=port) as cli:  # type: ignore[misc]
+            t = cli.get_table("demo", "users")  # type: ignore[attr-defined]
+            props = getattr(t, "parameters", {})
+            assert props.get("cps.pii.col.email") == "true"
+            assert props.get("cps.pii_types.col.email") == "EMAIL"
+            col = next(c for c in getattr(t.sd, "cols", []) if c.name == "email")
+            assert "PII detected" in (col.comment or "")
+
+        # Idempotent second run
+        res2 = runner.invoke(
+            app,
+            [
+                "scan",
+                "--target",
+                "hms://*",
+                "--apply",
+                "--type",
+                "EMAIL",
+                "--append-comment",
+                "PII detected",
+            ],
+        )
+        assert res2.exit_code == 0
+        with hmsclient.HMSClient(host="127.0.0.1", port=port) as cli:  # type: ignore[misc]
+            t2 = cli.get_table("demo", "users")  # type: ignore[attr-defined]
+            col2 = next(c for c in getattr(t2.sd, "cols", []) if c.name == "email")
+            assert (col2.comment or "").count("PII detected") == 1


### PR DESCRIPTION
Introduces HiveMetastoreClient for Thrift-based HMS catalog enumeration and tagging. Updates CLI to support 'hms://' targets for scanning and applying PII tags. Adds tests for HMS integration using both a fake client and testcontainers. Updates pyproject.toml with 'testcontainers' and 'hmsclient' as dev dependencies.