### PR TITLE
Add JDBCSampler and connection pool with tests

### DIFF
--- a/src/catalog_pii_scanner/sampler.py
+++ b/src/catalog_pii_scanner/sampler.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Generator, Iterable
+from contextlib import contextmanager
+from typing import Any
+
+
+class ConnectionPool:
+    """Very small DB-API connection pool.
+
+    - Accepts a `connect` callable that returns a DB-API connection.
+    - Keeps up to `maxsize` idle connections for reuse.
+    - Single-threaded friendly (no blocking/waiting semantics).
+    """
+
+    def __init__(self, connect: Callable[[], Any], maxsize: int = 4) -> None:
+        if not callable(connect):
+            raise TypeError("connect must be a callable returning a DB-API connection")
+        self._connect = connect
+        self._maxsize = max(1, int(maxsize))
+        self._pool: list[Any] = []
+
+    @contextmanager
+    def acquire(self) -> Generator[Any, None, None]:
+        # Reuse if possible; else create new
+        conn = self._pool.pop() if self._pool else self._connect()
+        try:
+            yield conn
+        finally:
+            # Return to pool if not full; else close
+            if len(self._pool) < self._maxsize:
+                self._pool.append(conn)
+            else:
+                try:
+                    conn.close()  # type: ignore[no-untyped-call]
+                except Exception:
+                    pass
+
+    def closeall(self) -> None:
+        while self._pool:
+            conn = self._pool.pop()
+            try:
+                conn.close()  # type: ignore[no-untyped-call]
+            except Exception:
+                pass
+
+
+class JDBCSampler:
+    """Generic JDBC sampler for Hive/Spark/DBSQL-like engines.
+
+    Features:
+    - Simple connection pooling (or use a provided connection)
+    - Randomized sampling via TABLESAMPLE when available
+    - Fallback to ORDER BY RAND()/rand() LIMIT N, then plain LIMIT
+
+    This class operates over DB-API connections and keeps SQL portable.
+    """
+
+    def __init__(
+        self,
+        *,
+        conn: Any | None = None,
+        connect: Callable[[], Any] | None = None,
+        max_pool_size: int = 2,
+        arraysize: int = 1000,
+        prefer_tablesample: bool = True,
+    ) -> None:
+        if conn is None and connect is None:
+            raise ValueError("Provide either an existing 'conn' or a 'connect' callable")
+        if conn is not None and connect is not None:
+            raise ValueError("Provide only one of 'conn' or 'connect', not both")
+
+        self._conn = conn
+        self._pool = ConnectionPool(connect, max_pool_size) if connect else None
+        self.arraysize = max(1, int(arraysize))
+        self.prefer_tablesample = prefer_tablesample
+
+    def close(self) -> None:
+        if self._pool is not None:
+            self._pool.closeall()
+
+    # ------------------------
+    # Public API
+    # ------------------------
+    def sample_column(
+        self,
+        *,
+        table: str,
+        column: str,
+        n: int,
+        where: str | None = None,
+    ) -> list[Any]:
+        """Return up to N non-null sampled values from table.column.
+
+        Attempts strategies in order until it collects N values:
+          1) TABLESAMPLE with increasing percentage + LIMIT
+          2) ORDER BY RAND()/rand() LIMIT
+          3) Plain LIMIT
+        """
+        n = max(1, int(n))
+        values: list[Any] = []
+        seen: set[Any] = set()
+
+        def add_rows(rows: list[tuple[Any, ...]] | Iterable[tuple[Any, ...]]) -> None:
+            nonlocal values
+            for r in rows:
+                if not r:
+                    continue
+                v = r[0]
+                if v is None:
+                    continue
+                if v in seen:
+                    continue
+                values.append(v)
+                seen.add(v)
+                if len(values) >= n:
+                    break
+
+        def _where_clause() -> str:
+            parts: list[str] = []
+            if where and where.strip():
+                parts.append(f"({where})")
+            parts.append(f"{column} IS NOT NULL")
+            return (" WHERE " + " AND ".join(parts)) if parts else ""
+
+        def _fetch(cur: Any, sql: str) -> None:
+            cur.execute(sql)
+            # Fetch at most 2n to allow filtering/uniques
+            fetch = getattr(cur, "fetchmany", None)
+            if callable(fetch):
+                rows = cur.fetchmany(max(n * 2, self.arraysize))
+            else:
+                rows = cur.fetchall()
+            add_rows(rows)
+
+        def _run_sampling(cur: Any) -> None:
+            # 1) TABLESAMPLE with ramping percentages
+            if self.prefer_tablesample:
+                for pct in (1, 2, 5, 10, 20, 50, 100):
+                    if len(values) >= n:
+                        break
+                    try:
+                        sql = (
+                            f"SELECT {column} FROM {table} "
+                            f"TABLESAMPLE ({pct} PERCENT)"
+                            f"{_where_clause()} LIMIT {max(n * 2, 10)}"
+                        )
+                        _fetch(cur, sql)
+                    except Exception:
+                        # Likely unsupported; move to next strategy
+                        break
+
+            # 2) ORDER BY RAND()/rand() LIMIT
+            if len(values) < n:
+                for fn in ("RAND()", "rand()"):
+                    if len(values) >= n:
+                        break
+                    try:
+                        sql = (
+                            f"SELECT {column} FROM {table}{_where_clause()} "
+                            f"ORDER BY {fn} LIMIT {n}"
+                        )
+                        _fetch(cur, sql)
+                        if len(values) >= n:
+                            break
+                    except Exception:
+                        continue
+
+            # 3) Plain LIMIT as last resort
+            if len(values) < n:
+                try:
+                    sql = f"SELECT {column} FROM {table}{_where_clause()} LIMIT {max(n * 2, 10)}"
+                    _fetch(cur, sql)
+                except Exception:
+                    # give up
+                    pass
+
+        # Acquire connection (pooled or direct)
+        if self._pool is not None:
+            with self._pool.acquire() as conn:
+                cur = conn.cursor()
+                try:
+                    if hasattr(cur, "arraysize"):
+                        cur.arraysize = self.arraysize
+                except Exception:
+                    pass
+                _run_sampling(cur)
+                try:
+                    cur.close()
+                except Exception:
+                    pass
+        else:
+            assert self._conn is not None
+            cur = self._conn.cursor()
+            try:
+                if hasattr(cur, "arraysize"):
+                    cur.arraysize = self.arraysize
+            except Exception:
+                pass
+            _run_sampling(cur)
+            try:
+                cur.close()
+            except Exception:
+                pass
+
+        return values[:n]
+
+
+__all__ = [
+    "ConnectionPool",
+    "JDBCSampler",
+]

--- a/tests/test_jdbc_sampler.py
+++ b/tests/test_jdbc_sampler.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from catalog_pii_scanner.sampler import JDBCSampler
+
+
+class _FakeCursor:
+    def __init__(
+        self,
+        *,
+        rows: list[Any],
+        support_tablesample: bool,
+        support_rand: bool,
+        record: list[str],
+    ) -> None:
+        self._all_rows = rows
+        self._results: list[tuple[Any]] = []
+        self.arraysize = 1
+        self._support_ts = support_tablesample
+        self._support_rand = support_rand
+        self._record = record
+
+    def execute(self, sql: str, params: Iterable[Any] | None = None) -> None:  # noqa: ARG002
+        self._record.append(sql)
+        s = sql.lower()
+        if "tablesample" in s and not self._support_ts:
+            raise RuntimeError("TABLESAMPLE not supported")
+        if "order by rand()" in s and not self._support_rand:
+            raise RuntimeError("RAND not supported")
+        if "order by rand(" in s and not self._support_rand:
+            raise RuntimeError("rand not supported")
+
+        # Naive LIMIT parser
+        lim = 10
+        if " limit " in s:
+            try:
+                lim = int(s.split(" limit ")[-1].split()[0])
+            except Exception:
+                lim = 10
+        # Filter out Nones as the sampler would
+        base = [r for r in self._all_rows if r is not None]
+        self._results = [(v,) for v in base[:lim]]
+
+    def fetchmany(self, n: int) -> list[tuple[Any, ...]]:
+        out = self._results[:n]
+        self._results = self._results[n:]
+        return out
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        out = self._results
+        self._results = []
+        return out
+
+    def close(self) -> None:  # pragma: no cover - not essential for logic
+        pass
+
+
+class _FakeConn:
+    def __init__(
+        self,
+        *,
+        rows: list[Any],
+        support_tablesample: bool = True,
+        support_rand: bool = True,
+        record: list[str] | None = None,
+    ) -> None:
+        self.rows = rows
+        self.support_tablesample = support_tablesample
+        self.support_rand = support_rand
+        self.record = record if record is not None else []
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(
+            rows=self.rows,
+            support_tablesample=self.support_tablesample,
+            support_rand=self.support_rand,
+            record=self.record,
+        )
+
+    def close(self) -> None:  # pragma: no cover - not essential for logic
+        self.closed = True
+
+
+def test_jdbc_sampler_tablesample_first() -> None:
+    record: list[str] = []
+    fake = _FakeConn(rows=["a", "b", None, "c", "d"], record=record)
+
+    sampler = JDBCSampler(conn=fake, prefer_tablesample=True)
+    out = sampler.sample_column(table="demo.public.users", column="email", n=3)
+
+    assert out == ["a", "b", "c"]
+    # First strategy should be TABLESAMPLE
+    assert any("tablesample" in s.lower() for s in record)
+
+
+def test_jdbc_sampler_fallback_to_rand() -> None:
+    record: list[str] = []
+    fake = _FakeConn(
+        rows=[1, 2, 3, 4, 5], support_tablesample=False, support_rand=True, record=record
+    )
+
+    sampler = JDBCSampler(conn=fake, prefer_tablesample=True)
+    out = sampler.sample_column(table="db.tbl", column="x", n=2)
+
+    assert out == [1, 2]
+    # Should have used ORDER BY RAND()
+    assert any("order by rand" in s.lower() for s in record)
+
+
+def test_jdbc_sampler_fallback_to_limit_only() -> None:
+    record: list[str] = []
+    fake = _FakeConn(
+        rows=["u1", "u2", "u3"],
+        support_tablesample=False,
+        support_rand=False,
+        record=record,
+    )
+
+    sampler = JDBCSampler(conn=fake)
+    out = sampler.sample_column(table="db.tbl", column="user", n=2)
+    assert out == ["u1", "u2"]
+    # Should fall back to LIMIT
+    assert any(" limit " in s.lower() and "order by" not in s.lower() for s in record)
+
+
+def test_jdbc_sampler_connection_pooling_reuse() -> None:
+    # Connect callable should be called only once due to pooling
+    calls = {"n": 0}
+    record1: list[str] = []
+    record2: list[str] = []
+
+    def _connect() -> _FakeConn:
+        calls["n"] += 1
+        # each connection gets its own record to ensure we reuse the same one
+        rec = record1 if calls["n"] == 1 else record2
+        return _FakeConn(rows=[10, 20, 30, 40], record=rec)
+
+    sampler = JDBCSampler(connect=_connect, max_pool_size=1)
+
+    out1 = sampler.sample_column(table="t", column="c", n=2)
+    out2 = sampler.sample_column(table="t", column="c", n=2)
+
+    assert out1 == [10, 20]
+    assert out2 == [10, 20]
+    assert calls["n"] == 1  # connection reused from pool
+    # All queries should land on the same underlying connection's record
+    assert record2 == []


### PR DESCRIPTION
Introduces a generic JDBCSampler class for sampling column values from JDBC-like databases, supporting TABLESAMPLE, ORDER BY RAND, and LIMIT strategies. Also adds a lightweight ConnectionPool for DB-API connections and comprehensive unit tests covering sampling strategies and connection pooling behavior.