### PR TITLE
Add support for MAC, Aadhaar, and PAN PII types

### DIFF
--- a/src/catalog_pii_scanner/pii_types.py
+++ b/src/catalog_pii_scanner/pii_types.py
@@ -11,6 +11,9 @@ class PIIType(str, Enum):
     CREDIT_CARD = "CREDIT_CARD"
     SSN = "SSN"
     IP_ADDRESS = "IP_ADDRESS"
+    MAC_ADDRESS = "MAC_ADDRESS"
+    AADHAAR = "AADHAAR"
+    PAN = "PAN"
     PERSON = "PERSON"
     ADDRESS = "ADDRESS"
     DATE = "DATE"
@@ -22,6 +25,9 @@ ALL_PII_TYPES: tuple[PIIType, ...] = (
     PIIType.CREDIT_CARD,
     PIIType.SSN,
     PIIType.IP_ADDRESS,
+    PIIType.MAC_ADDRESS,
+    PIIType.AADHAAR,
+    PIIType.PAN,
     PIIType.PERSON,
     PIIType.ADDRESS,
     PIIType.DATE,

--- a/src/catalog_pii_scanner/rules.py
+++ b/src/catalog_pii_scanner/rules.py
@@ -1,20 +1,35 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 
 from .pii_types import ALL_PII_TYPES, Candidate, PIIType, Span
 
-# Regex patterns for common PII
+# Regex patterns for common PII (precompiled)
 EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
-# Looser start boundary to allow leading '(' or '+' etc.
-PHONE_RE = re.compile(r"(?:\+?\d{1,3}[\s.-]?)?(?:\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}\b")
+# US-like phone numbers; allows country code and punctuation
+PHONE_US_RE = re.compile(r"(?:\+?\d{1,3}[\s.-]?)?(?:\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}\b")
+# Generic credit card digit sequences; validated by Luhn
 CC_RE = re.compile(r"\b(?:\d[ -]*?){13,19}\b")
+# US SSN
 SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
-IP_RE = re.compile(r"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b")
-DATE_RE = re.compile(r"\b\d{4}-\d{2}-\d{2}\b|\b\d{2}/\d{2}/\d{4}\b")
+# IPv4
+IPV4_RE = re.compile(r"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b")
+# MAC address (colon or dash separated)
+MAC_RE = re.compile(r"\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b")
+# Dates: ISO or common slashed formats (will be boosted if near DOB keywords)
+DATE_RE = re.compile(r"\b(?:\d{4}-\d{2}-\d{2}|\d{2}/\d{2}/\d{4}|\d{2}-\d{2}-\d{4})\b")
+# Aadhaar: 12 digits (first digit 2-9), optional spaces/hyphens; validated via Verhoeff
+AADHAAR_RE = re.compile(r"\b([2-9][0-9]{3}[ -]?[0-9]{4}[ -]?[0-9]{4})\b")
+# Indian PAN: 5 letters + 4 digits + 1 letter
+PAN_RE = re.compile(r"\b([A-Z]{5}[0-9]{4}[A-Z])\b", flags=re.IGNORECASE)
 
-# Basic name detection (very weak, used only when context suggests)
+# Basic person name (very weak)
 PERSON_RE = re.compile(r"\b([A-Z][a-z]+\s[A-Z][a-z]+)\b")
+
+
+# ---------------- Checksums/validators ----------------
 
 
 def luhn_check(number: str) -> bool:
@@ -32,38 +47,122 @@ def luhn_check(number: str) -> bool:
     return checksum % 10 == 0
 
 
+# Verhoeff algorithm used by Aadhaar (base 10)
+_VERHOEFF_D = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    [1, 2, 3, 4, 0, 6, 7, 8, 9, 5],
+    [2, 3, 4, 0, 1, 7, 8, 9, 5, 6],
+    [3, 4, 0, 1, 2, 8, 9, 5, 6, 7],
+    [4, 0, 1, 2, 3, 9, 5, 6, 7, 8],
+    [5, 9, 8, 7, 6, 0, 4, 3, 2, 1],
+    [6, 5, 9, 8, 7, 1, 0, 4, 3, 2],
+    [7, 6, 5, 9, 8, 2, 1, 0, 4, 3],
+    [8, 7, 6, 5, 9, 3, 2, 1, 0, 4],
+    [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+]
+_VERHOEFF_P = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    [1, 5, 7, 6, 2, 8, 3, 0, 9, 4],
+    [5, 8, 0, 3, 7, 9, 6, 1, 4, 2],
+    [8, 9, 1, 6, 0, 4, 3, 5, 2, 7],
+    [9, 4, 5, 3, 1, 2, 6, 8, 7, 0],
+    [4, 2, 8, 6, 5, 7, 3, 9, 0, 1],
+    [2, 7, 9, 3, 8, 0, 6, 4, 1, 5],
+    [7, 0, 4, 6, 9, 1, 3, 2, 5, 8],
+]
+
+
+def verhoeff_check(number: str) -> bool:
+    s = re.sub(r"\D", "", number)
+    if len(s) != 12:
+        return False
+    # Aadhaar must not start with 0/1
+    if s[0] in {"0", "1"}:
+        return False
+    c = 0
+    # Process from right to left
+    for i, ch in enumerate(reversed(s)):
+        c = _VERHOEFF_D[c][_VERHOEFF_P[i % 8][int(ch)]]
+    return c == 0
+
+
 def find_regex(text: str, regex: re.Pattern[str]) -> list[Span]:
     return [Span(m.start(), m.end(), m.group(0)) for m in regex.finditer(text)]
 
 
-def propose_candidates(text: str) -> list[Candidate]:
+@dataclass(frozen=True)
+class RulesConfig:
+    enabled_types: frozenset[PIIType] | None = None  # None -> all types
+    locales: frozenset[str] = frozenset({"US", "IN"})
+
+    def enabled(self, t: PIIType) -> bool:
+        return (self.enabled_types is None) or (t in self.enabled_types)
+
+
+def _enabled(t: PIIType, cfg: RulesConfig | None) -> bool:
+    return True if cfg is None else cfg.enabled(t)
+
+
+def propose_candidates(text: str, cfg: RulesConfig | None = None) -> list[Candidate]:
     cands: list[Candidate] = []
     # Order matters a bit; add specific patterns first
-    for span in find_regex(text, EMAIL_RE):
-        cands.append(Candidate(span=span, rule_label=PIIType.EMAIL, rule_confidence=0.95))
-    for span in find_regex(text, PHONE_RE):
-        cands.append(Candidate(span=span, rule_label=PIIType.PHONE_NUMBER, rule_confidence=0.85))
-    # Credit cards: validate with Luhn
-    for span in find_regex(text, CC_RE):
-        cc_ok = luhn_check(span.text)
-        conf = 0.9 if cc_ok else 0.5
-        cands.append(
-            Candidate(
-                span=span,
-                rule_label=PIIType.CREDIT_CARD if cc_ok else None,
-                rule_confidence=conf,
-                validations={PIIType.CREDIT_CARD: cc_ok},
+    if _enabled(PIIType.EMAIL, cfg):
+        for span in find_regex(text, EMAIL_RE):
+            cands.append(Candidate(span=span, rule_label=PIIType.EMAIL, rule_confidence=0.95))
+    if _enabled(PIIType.PHONE_NUMBER, cfg):
+        for span in find_regex(text, PHONE_US_RE):
+            cands.append(
+                Candidate(span=span, rule_label=PIIType.PHONE_NUMBER, rule_confidence=0.85)
             )
-        )
-    for span in find_regex(text, SSN_RE):
-        cands.append(Candidate(span=span, rule_label=PIIType.SSN, rule_confidence=0.9))
-    for span in find_regex(text, IP_RE):
-        cands.append(Candidate(span=span, rule_label=PIIType.IP_ADDRESS, rule_confidence=0.9))
-    for span in find_regex(text, DATE_RE):
-        cands.append(Candidate(span=span, rule_label=PIIType.DATE, rule_confidence=0.7))
+    # Credit cards: validate with Luhn
+    if _enabled(PIIType.CREDIT_CARD, cfg):
+        for span in find_regex(text, CC_RE):
+            cc_ok = luhn_check(span.text)
+            if cc_ok:
+                cands.append(
+                    Candidate(
+                        span=span,
+                        rule_label=PIIType.CREDIT_CARD,
+                        rule_confidence=0.9,
+                        validations={PIIType.CREDIT_CARD: True},
+                    )
+                )
+    if _enabled(PIIType.SSN, cfg):
+        for span in find_regex(text, SSN_RE):
+            cands.append(Candidate(span=span, rule_label=PIIType.SSN, rule_confidence=0.9))
+    if _enabled(PIIType.IP_ADDRESS, cfg):
+        for span in find_regex(text, IPV4_RE):
+            cands.append(Candidate(span=span, rule_label=PIIType.IP_ADDRESS, rule_confidence=0.9))
+    if _enabled(PIIType.MAC_ADDRESS, cfg):
+        for span in find_regex(text, MAC_RE):
+            cands.append(Candidate(span=span, rule_label=PIIType.MAC_ADDRESS, rule_confidence=0.9))
+    if _enabled(PIIType.AADHAAR, cfg):
+        for span in find_regex(text, AADHAAR_RE):
+            if verhoeff_check(span.text):
+                cands.append(
+                    Candidate(
+                        span=span,
+                        rule_label=PIIType.AADHAAR,
+                        rule_confidence=0.9,
+                        validations={PIIType.AADHAAR: True},
+                    )
+                )
+    if _enabled(PIIType.PAN, cfg):
+        for span in find_regex(text, PAN_RE):
+            # Compiled regex is already strict; set label
+            cands.append(Candidate(span=span, rule_label=PIIType.PAN, rule_confidence=0.9))
+    if _enabled(PIIType.DATE, cfg):
+        for span in find_regex(text, DATE_RE):
+            # Boost if near DOB keywords
+            left = max(0, span.start - 8)
+            right = min(len(text), span.end + 8)
+            ctx = text[left:right].lower()
+            boost = 0.1 if ("dob" in ctx or "birth" in ctx) else 0.0
+            cands.append(Candidate(span=span, rule_label=PIIType.DATE, rule_confidence=0.7 + boost))
     # Person names: low confidence; rely on context and ensemble
-    for span in find_regex(text, PERSON_RE):
-        cands.append(Candidate(span=span, rule_label=PIIType.PERSON, rule_confidence=0.4))
+    if _enabled(PIIType.PERSON, cfg):
+        for span in find_regex(text, PERSON_RE):
+            cands.append(Candidate(span=span, rule_label=PIIType.PERSON, rule_confidence=0.4))
     return cands
 
 
@@ -79,3 +178,64 @@ def candidate_feature_vector(c: Candidate) -> dict[str, float | int | bool]:
         feats[f"val_{t.value}"] = bool(c.validations.get(t, False) if c.validations else False)
         feats[f"rule_is_{t.value}"] = 1 if c.rule_label == t else 0
     return feats
+
+
+# ---------------- Metadata keyword heuristics ----------------
+_KEYWORDS: dict[PIIType, tuple[str, ...]] = {
+    PIIType.EMAIL: (
+        "email",
+        "e-mail",
+        "mailid",
+        "mail_id",
+        "email_address",
+        "primary_email",
+    ),
+    PIIType.PHONE_NUMBER: (
+        "phone",
+        "mobile",
+        "cell",
+        "contact",
+        "telephone",
+        "mobile_no",
+        "phone_number",
+    ),
+    PIIType.SSN: ("ssn", "social_security"),
+    PIIType.AADHAAR: ("aadhaar", "aadhar", "uidai", "uid"),
+    PIIType.PAN: ("pan", "pan_no", "pan_number"),
+    PIIType.CREDIT_CARD: ("card", "credit", "cc", "cc_number"),
+    PIIType.IP_ADDRESS: ("ip", "ipv4", "ipv6"),
+    PIIType.MAC_ADDRESS: ("mac", "mac_address"),
+    PIIType.DATE: ("dob", "date_of_birth", "birthdate"),
+    PIIType.PERSON: ("name", "first_name", "last_name", "full_name"),
+}
+
+
+def keyword_candidates_from_metadata(
+    metadata: Mapping[str, str] | Iterable[tuple[str, str]],
+    cfg: RulesConfig | None = None,
+) -> list[Candidate]:
+    pairs: list[tuple[str, str]]
+    if isinstance(metadata, Mapping):
+        pairs = list(metadata.items())
+    else:
+        pairs = list(metadata)
+    out: list[Candidate] = []
+    for _field, value in pairs:
+        if not value:
+            continue
+        hay = value.lower()
+        for t, kws in _KEYWORDS.items():
+            if not _enabled(t, cfg):
+                continue
+            for kw in kws:
+                idx = hay.find(kw)
+                if idx != -1:
+                    out.append(
+                        Candidate(
+                            span=Span(idx, idx + len(kw), value[idx : idx + len(kw)]),
+                            rule_label=t,
+                            rule_confidence=0.6,
+                        )
+                    )
+                    break
+    return out

--- a/tests/test_rules_advanced.py
+++ b/tests/test_rules_advanced.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from catalog_pii_scanner.pii_types import PIIType
+from catalog_pii_scanner.rules import (
+    RulesConfig,
+    keyword_candidates_from_metadata,
+    luhn_check,
+    propose_candidates,
+    verhoeff_check,
+)
+
+
+def test_detect_mac_aadhaar_pan_and_dob() -> None:
+    # Build a valid Aadhaar by brute-forcing the last digit for a fixed 11-digit prefix
+    prefix = "23456789012"  # starts with 2, 11 digits
+    aadhaar = None
+    for d in range(10):
+        cand = f"{prefix}{d}"
+        if verhoeff_check(cand):
+            aadhaar = cand
+            break
+    assert aadhaar is not None, "Failed to build a valid Aadhaar test number"
+
+    text = f"Device MAC aa:bb:cc:dd:ee:ff, PAN ABCDE1234F, DOB: 31/12/1990, Aadhaar {aadhaar}."
+    cands = propose_candidates(text)
+    labels = {c.rule_label for c in cands if c.rule_label}
+    assert PIIType.MAC_ADDRESS in labels
+    assert PIIType.PAN in labels
+    assert PIIType.DATE in labels
+    assert PIIType.AADHAAR in labels
+
+
+def test_rules_config_disable_types() -> None:
+    text = "Reach me at john@example.com or (415) 555-0000"
+    cfg = RulesConfig(enabled_types=frozenset({PIIType.EMAIL}))
+    cands = propose_candidates(text, cfg)
+    labels = [c.rule_label for c in cands if c.rule_label]
+    assert PIIType.EMAIL in labels
+    assert PIIType.PHONE_NUMBER not in labels
+
+
+def test_metadata_keyword_heuristics() -> None:
+    meta = {
+        "name": "user_pan_number",
+        "description": "primary email address for contact",
+        "tags": "customer, pii",
+    }
+    hints = keyword_candidates_from_metadata(meta)
+    types = {h.rule_label for h in hints if h.rule_label}
+    assert PIIType.PAN in types
+    assert PIIType.EMAIL in types
+
+
+def test_false_positives_filtered() -> None:
+    # PAN-like but invalid (missing last letter)
+    txt1 = "PAN ABCDE12345 is invalid"
+    labs1 = {c.rule_label for c in propose_candidates(txt1) if c.rule_label}
+    assert PIIType.PAN not in labs1
+
+    # Aadhaar-like but invalid (starts with 1 or fails verhoeff)
+    txt2 = "Aadhaar 1234 5678 9012"
+    labs2 = {c.rule_label for c in propose_candidates(txt2) if c.rule_label}
+    assert PIIType.AADHAAR not in labs2
+
+    # Credit card invalid Luhn should not be labelled as CC
+    txt3 = "Card 4111 1111 1111 1112"
+    assert not luhn_check("4111 1111 1111 1112")
+    labs3 = {c.rule_label for c in propose_candidates(txt3) if c.rule_label}
+    assert PIIType.CREDIT_CARD not in labs3


### PR DESCRIPTION
Extended PIIType enum and detection logic to include MAC address, Aadhaar, and PAN. Added regex and validation for these types, including Verhoeff checksum for Aadhaar. Introduced RulesConfig for configurable detection, keyword-based metadata heuristics, and comprehensive tests for new types and configuration options.