### PR TITLE
Add NER provider abstraction and tests

### DIFF
--- a/src/catalog_pii_scanner/config.py
+++ b/src/catalog_pii_scanner/config.py
@@ -15,6 +15,9 @@ class NERConfig(BaseModel):
     enabled: bool = True
     provider: Literal["presidio", "spacy"] = "presidio"
     confidence_min: float = Field(0.60, ge=0.0, le=1.0)
+    # Language code hint (e.g., 'en'). For spaCy, optionally specify model name.
+    language: str = "en"
+    spacy_model: str | None = None
 
 
 class EmbeddingsFeaturesConfig(BaseModel):

--- a/src/catalog_pii_scanner/connectors/athena.py
+++ b/src/catalog_pii_scanner/connectors/athena.py
@@ -113,7 +113,7 @@ class AthenaSampler:
             where_clause = " WHERE " + " AND ".join(parts)
 
         # Order randomly to get samples; LIMIT caps the output size
-        sql = f"SELECT {column} FROM {table}{where_clause} " f"ORDER BY rand() LIMIT {n}"
+        sql = f"SELECT {column} FROM {table}{where_clause} ORDER BY rand() LIMIT {n}"
         qid = self._start_query(sql, database)
         self._wait(qid)
         rows = self._collect_results(qid, max_rows=n)

--- a/src/catalog_pii_scanner/datasets.py
+++ b/src/catalog_pii_scanner/datasets.py
@@ -22,7 +22,9 @@ def _random_email() -> str:
 
 def _random_phone() -> str:
     # US-like phone
-    return f"({random.randint(200,999)}) {random.randint(200,999):03d}-{random.randint(0,9999):04d}"
+    return (
+        f"({random.randint(200, 999)}) {random.randint(200, 999):03d}-{random.randint(0, 9999):04d}"
+    )
 
 
 def _luhnify(base16: str) -> str:
@@ -49,7 +51,9 @@ def _random_cc() -> str:
 
 
 def _random_ssn() -> str:
-    return f"{random.randint(100,999)}-{random.randint(10,99):02d}-{random.randint(1000,9999):04d}"
+    return (
+        f"{random.randint(100, 999)}-{random.randint(10, 99):02d}-{random.randint(1000, 9999):04d}"
+    )
 
 
 def _random_ip() -> str:

--- a/src/catalog_pii_scanner/ner.py
+++ b/src/catalog_pii_scanner/ner.py
@@ -158,9 +158,17 @@ def detect_ner_spans(
     - Applies confidence gating from cfg if provided (post-filter at consumer if custom).
     - Returns a list aligned to the input texts; each entry is a list of NERSpan.
     """
-    cfg = cfg or NERConfig()
+    # Be explicit for mypy: provide all named args to satisfy BaseModel constructor typing
+    cfg = cfg or NERConfig(
+        enabled=True,
+        provider="presidio",
+        confidence_min=0.60,
+        language="en",
+        spacy_model=None,
+    )
     prov = provider or get_provider(cfg)
-    all_spans = prov.analyze_batch(texts, language=cfg.language)
+    # Call with positional arg to be robust to provider signatures
+    all_spans = prov.analyze_batch(texts, cfg.language)
     # Apply global gating
     gated: list[list[NERSpan]] = []
     for spans in all_spans:

--- a/src/catalog_pii_scanner/ner.py
+++ b/src/catalog_pii_scanner/ner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from functools import lru_cache
 
 try:
@@ -7,18 +9,195 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     spacy = None  # type: ignore
 
-from .pii_types import PIIType
+from .config import NERConfig
+from .pii_types import PIIType, Span
+from .rules import EMAIL_RE, PHONE_US_RE
+
+# ---------------- spaCy loading helpers ----------------
 
 
-@lru_cache(maxsize=1)
-def _load_spacy() -> spacy.Language | None:
+@lru_cache(maxsize=8)
+def _load_spacy(model: str | None, language: str = "en") -> spacy.Language | None:
     if spacy is None:
         return None
     try:
-        # Try small English model; if missing, fall back to blank English
+        if model:
+            return spacy.load(model)  # type: ignore[arg-type]
+        # Try small English model; if missing, fall back to blank
         return spacy.load("en_core_web_sm")  # type: ignore[arg-type]
     except Exception:
-        return spacy.blank("en")  # type: ignore[no-any-return]
+        try:
+            return spacy.blank(language)
+        except Exception:
+            return None
+
+
+# ---------------- Public datatypes ----------------
+
+
+@dataclass(frozen=True)
+class NERSpan:
+    span: Span
+    label: PIIType
+    score: float
+
+
+# ---------------- Providers ----------------
+
+
+class NERProvider:
+    def analyze_batch(self, texts: Sequence[str], language: str = "en") -> list[list[NERSpan]]:
+        raise NotImplementedError
+
+
+class SpaCyProvider(NERProvider):
+    def __init__(self, model: str | None = None) -> None:
+        self.model = model
+
+    def analyze_batch(self, texts: Sequence[str], language: str = "en") -> list[list[NERSpan]]:
+        nlp = _load_spacy(self.model, language)
+        out: list[list[NERSpan]] = []
+        if nlp is None:
+            return [[] for _ in texts]
+        docs = list(nlp.pipe(texts, disable=["tagger", "lemmatizer"]))
+        for text, doc in zip(texts, docs, strict=False):
+            spans: list[NERSpan] = []
+            # PERSON via spaCy ents
+            for ent in getattr(doc, "ents", []) or []:
+                if ent.label_ == "PERSON":
+                    spans.append(
+                        NERSpan(
+                            span=Span(
+                                ent.start_char, ent.end_char, text[ent.start_char : ent.end_char]
+                            ),
+                            label=PIIType.PERSON,
+                            score=0.85,
+                        )
+                    )
+            # EMAIL via robust regex
+            for m in EMAIL_RE.finditer(text):
+                spans.append(
+                    NERSpan(
+                        span=Span(m.start(), m.end(), m.group(0)), label=PIIType.EMAIL, score=0.99
+                    )
+                )
+            # PHONE via robust regex
+            for m in PHONE_US_RE.finditer(text):
+                spans.append(
+                    NERSpan(
+                        span=Span(m.start(), m.end(), m.group(0)),
+                        label=PIIType.PHONE_NUMBER,
+                        score=0.90,
+                    )
+                )
+            out.append(spans)
+        return out
+
+
+class PresidioProvider(NERProvider):  # pragma: no cover - exercised via mocks in tests
+    def __init__(self) -> None:
+        self._engine = None
+        self._init()
+
+    def _init(self) -> None:
+        if self._engine is not None:
+            return
+        # Defer heavy imports
+        if __import__("os").environ.get("CPS_OFFLINE"):
+            self._engine = None
+            return
+        try:
+            from presidio_analyzer import AnalyzerEngine  # type: ignore
+
+            self._engine = AnalyzerEngine()
+        except Exception:
+            self._engine = None
+
+    def analyze_batch(self, texts: Sequence[str], language: str = "en") -> list[list[NERSpan]]:
+        if self._engine is None:
+            return [[] for _ in texts]
+        out: list[list[NERSpan]] = []
+        for text in texts:
+            try:
+                results = self._engine.analyze(text=text, language=language)  # type: ignore[no-untyped-call]
+            except Exception:
+                results = []
+            spans: list[NERSpan] = []
+            for r in results or []:
+                # Presidio entity labels; map to our PIIType
+                et = str(getattr(r, "entity_type", "")).upper()
+                start = int(getattr(r, "start", 0))
+                end = int(getattr(r, "end", 0))
+                score = float(getattr(r, "score", 0.0))
+                text_span = text[start:end]
+                if et in {"PERSON", "PER"}:
+                    label = PIIType.PERSON
+                elif et in {"EMAIL", "EMAIL_ADDRESS"}:
+                    label = PIIType.EMAIL
+                elif et in {"PHONE", "PHONE_NUMBER", "PHONENUMBER"}:
+                    label = PIIType.PHONE_NUMBER
+                else:
+                    # ignore other labels for now
+                    continue
+                spans.append(NERSpan(span=Span(start, end, text_span), label=label, score=score))
+            out.append(spans)
+        return out
+
+
+def get_provider(cfg: NERConfig) -> NERProvider:
+    if cfg.provider == "presidio":
+        return PresidioProvider()
+    return SpaCyProvider(model=cfg.spacy_model)
+
+
+def detect_ner_spans(
+    texts: Sequence[str], cfg: NERConfig | None = None, provider: NERProvider | None = None
+) -> list[list[NERSpan]]:
+    """Detect NER spans for a batch of texts using the configured provider.
+
+    - Applies confidence gating from cfg if provided (post-filter at consumer if custom).
+    - Returns a list aligned to the input texts; each entry is a list of NERSpan.
+    """
+    cfg = cfg or NERConfig()
+    prov = provider or get_provider(cfg)
+    all_spans = prov.analyze_batch(texts, language=cfg.language)
+    # Apply global gating
+    gated: list[list[NERSpan]] = []
+    for spans in all_spans:
+        gated.append([s for s in spans if s.score >= cfg.confidence_min])
+    return gated
+
+
+def merge_with_rules(
+    text: str,
+    ner_spans: Iterable[NERSpan],
+    confidence_min: float = 0.0,
+) -> dict[PIIType, float]:
+    """Merge NER signals with rules layer by type and emit combined scores.
+
+    Strategy: per PII type, take the max across NER scores (after thresholding) and
+    rules heuristic scores if present (via direct regex confidences implied by patterns).
+    - EMAIL/PHONE from rules are treated as 0.95/0.85 priors (matching rules.py constants)
+    - PERSON defaults to NER only (rules PERSON is weak and optional)
+    """
+    from .rules import propose_candidates  # local import to avoid cycles during import time
+
+    # NER contribution
+    per_type: dict[PIIType, float] = {}
+    for s in ner_spans:
+        if s.score < max(0.0, confidence_min):
+            continue
+        per_type[s.label] = max(per_type.get(s.label, 0.0), float(s.score))
+
+    # Rules contribution
+    for c in propose_candidates(text):
+        if c.rule_label is None:
+            continue
+        per_type[c.rule_label] = max(per_type.get(c.rule_label, 0.0), float(c.rule_confidence))
+    return per_type
+
+
+# ---------------- Context-level signals (existing) ----------------
 
 
 def ner_context_signals(context_texts: dict[int, str]) -> dict[int, dict[str, float]]:
@@ -27,7 +206,7 @@ def ner_context_signals(context_texts: dict[int, str]) -> dict[int, dict[str, fl
     Returns a per-candidate dict of soft signals derived from context entity labels.
     This function never sees raw PII; contexts are expected to be redacted upstream.
     """
-    nlp = _load_spacy()
+    nlp = _load_spacy(model=None, language="en")
     signals: dict[int, dict[str, float]] = {}
     if nlp is None:
         for k in context_texts:

--- a/src/catalog_pii_scanner/sampler.py
+++ b/src/catalog_pii_scanner/sampler.py
@@ -184,8 +184,7 @@ class JDBCSampler:
                         break
                     try:
                         sql = (
-                            f"SELECT {column} FROM {table}{_where_clause()} "
-                            f"ORDER BY {fn} LIMIT {n}"
+                            f"SELECT {column} FROM {table}{_where_clause()} ORDER BY {fn} LIMIT {n}"
                         )
                         _fetch(cur, sql)
                         if len(values) >= n:

--- a/tests/test_athena_sampler.py
+++ b/tests/test_athena_sampler.py
@@ -66,7 +66,7 @@ def test_athena_sampler_samples_with_not_ready_then_success() -> None:
         {"QueryExecutionId": "q-123"},
         expected_params={
             "QueryString": (
-                "SELECT email FROM users WHERE email IS NOT NULL " "ORDER BY rand() LIMIT 2"
+                "SELECT email FROM users WHERE email IS NOT NULL ORDER BY rand() LIMIT 2"
             ),
             "WorkGroup": ANY,
             "QueryExecutionContext": {"Database": "demo"},

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+
+import pytest
+
+from catalog_pii_scanner.config import NERConfig
+from catalog_pii_scanner.ner import NERProvider, NERSpan, detect_ner_spans, merge_with_rules
+from catalog_pii_scanner.pii_types import PIIType, Span
+
+
+class FakeProvider(NERProvider):
+    def __init__(self, spans_for_text: list[NERSpan]):
+        self._spans_for_text = spans_for_text
+
+    def analyze_batch(self, texts: Sequence[str], _language: str = "en") -> list[list[NERSpan]]:
+        # Return the same spans for each text for simplicity
+        return [self._spans_for_text for _ in texts]
+
+
+def test_ner_mock_provider_detects_and_combines() -> None:
+    text = "Contact John Doe at john.doe@example.com or +1-415-555-1212."
+    person_idx = text.find("John Doe")
+    email_idx = text.find("john.doe@example.com")
+    phone_idx = text.find("+1-415-555-1212")
+    assert person_idx != -1 and email_idx != -1 and phone_idx != -1
+
+    fake_spans = [
+        NERSpan(
+            span=Span(person_idx, person_idx + len("John Doe"), "John Doe"),
+            label=PIIType.PERSON,
+            score=0.90,
+        ),
+        NERSpan(
+            span=Span(email_idx, email_idx + len("john.doe@example.com"), "john.doe@example.com"),
+            label=PIIType.EMAIL,
+            score=0.98,
+        ),
+        NERSpan(
+            span=Span(phone_idx, phone_idx + len("+1-415-555-1212"), "+1-415-555-1212"),
+            label=PIIType.PHONE_NUMBER,
+            score=0.92,
+        ),
+    ]
+
+    cfg = NERConfig(enabled=True, provider="presidio", confidence_min=0.60)
+    res = detect_ner_spans([text], cfg=cfg, provider=FakeProvider(fake_spans))
+    assert len(res) == 1 and len(res[0]) == 3
+    labels = {s.label for s in res[0]}
+    assert {PIIType.PERSON, PIIType.EMAIL, PIIType.PHONE_NUMBER} <= labels
+
+    # Merge with rule priors and check combined max behavior
+    combined = merge_with_rules(text, res[0], confidence_min=cfg.confidence_min)
+    assert combined[PIIType.PERSON] >= 0.90
+    # EMAIL: rule prior is 0.95, NER is 0.98 => combined 0.98
+    assert combined[PIIType.EMAIL] >= 0.98 - 1e-6
+    # PHONE: rule prior is 0.85, NER is 0.92 => combined 0.92
+    assert combined[PIIType.PHONE_NUMBER] >= 0.92 - 1e-6
+
+    # Increase threshold, only EMAIL remains after gating
+    cfg2 = NERConfig(enabled=True, provider="presidio", confidence_min=0.95)
+    res2 = detect_ner_spans([text], cfg=cfg2, provider=FakeProvider(fake_spans))
+    labs2 = {s.label for s in res2[0]}
+    assert labs2 == {PIIType.EMAIL}
+
+
+@pytest.mark.skipif(
+    not os.getenv("CPS_NER_SMOKE"), reason="NER smoke test disabled; set CPS_NER_SMOKE=1 to run"
+)
+def test_spacy_smoke_email_phone_detection() -> None:
+    # Even without spaCy NER model, fallback regex detects EMAIL/PHONE
+    os.environ.setdefault("CPS_OFFLINE", "1")
+    text = "Call John Doe at john@example.com or (415) 555-1212"
+    cfg = NERConfig(enabled=True, provider="spacy", confidence_min=0.6)
+    res = detect_ner_spans([text], cfg=cfg)
+    labs = {s.label for s in res[0]}
+    assert PIIType.EMAIL in labs
+    assert PIIType.PHONE_NUMBER in labs
+    # PERSON may be present if spaCy model available; don't assert


### PR DESCRIPTION
Refactored NER logic to support multiple providers (spaCy, Presidio) via a unified interface. Added configuration options for language and spaCy model selection. Implemented batch NER detection, confidence gating, and merging with rule-based signals. Added comprehensive unit tests for NER detection and merging logic.