### PR TITLE
Add bracket token redaction and context sanitization

### DIFF
--- a/src/catalog_pii_scanner/redaction.py
+++ b/src/catalog_pii_scanner/redaction.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from .pii_types import Candidate, Span
+from .ner import detect_ner_spans
+from .pii_types import Candidate, PIIType, Span
 
 
 @dataclass
@@ -45,6 +46,32 @@ def redact_text(text: str, spans: Iterable[Span]) -> Redaction:
     return Redaction(redacted_text="".join(out), replaced_spans=replaced)
 
 
+def token_for_label(label: PIIType) -> str:
+    # Standard bracket tokens for models/LLMs, e.g., [EMAIL]
+    return f"[{label.value}]"
+
+
+def typed_redact_text(text: str, labeled_spans: Iterable[tuple[Span, PIIType]]) -> Redaction:
+    """Redact text by replacing spans with bracket tokens like [EMAIL].
+
+    Does NOT preserve length (safe for embeddings/LLM). Overlapping spans are skipped in-order.
+    """
+    items = sorted(labeled_spans, key=lambda x: x[0].start)
+    out: list[str] = []
+    cursor = 0
+    replaced: list[tuple[Span, str]] = []
+    for s, t in items:
+        if s.start < cursor:
+            continue
+        out.append(text[cursor : s.start])
+        tok = token_for_label(t)
+        out.append(tok)
+        replaced.append((s, tok))
+        cursor = s.end
+    out.append(text[cursor:])
+    return Redaction(redacted_text="".join(out), replaced_spans=replaced)
+
+
 def assert_no_raw_pii_to_models(original: str, redacted: str, spans: Iterable[Span]) -> None:
     # Ensure that raw span texts don't appear in redacted payloads
     sset = {s.text for s in spans}
@@ -57,16 +84,45 @@ def assert_no_raw_pii_to_models(original: str, redacted: str, spans: Iterable[Sp
 def contexts_for_candidates(
     text: str, candidates: list[Candidate], window: int = 32
 ) -> dict[int, str]:
-    # Build small context windows around each candidate, redacting the candidate itself
+    """Build per-candidate sanitized context windows using typed tokens.
+
+    - Uses rule candidates' labels plus Presidio/spaCy NER to mask EMAIL/PHONE/ID/etc.
+    - Ensures no raw PII values from detected spans appear in the returned windows.
+    - Returns windows with normalized tokens like [EMAIL], suitable for embeddings/LLM.
+    """
     result: dict[int, str] = {}
-    spans = [c.span for c in candidates]
-    red = redact_text(text, spans)
-    assert_no_raw_pii_to_models(text, red.redacted_text, spans)
+
+    # Collect labeled spans from rules
+    labeled_spans: list[tuple[Span, PIIType]] = [
+        (c.span, c.rule_label) for c in candidates if c.rule_label is not None
+    ]  # type: ignore[list-item]
+
+    # Augment with NER (Presidio/spaCy/regex fallback) over full text
+    try:
+        ner_batches = detect_ner_spans([text])
+        if ner_batches and ner_batches[0]:
+            for ns in ner_batches[0]:
+                labeled_spans.append((ns.span, ns.label))
+    except Exception:
+        # NER is optional; proceed with rules-only
+        pass
+
+    # For each candidate, build a window and apply typed redaction for any spans intersecting it
     for idx, c in enumerate(candidates):
-        s = c.span
-        left = max(0, s.start - window)
-        right = min(len(text), s.end + window)
-        # Use the already-redacted text to avoid raw PII
-        context = red.redacted_text[left:right]
-        result[idx] = context
+        cand_span = c.span
+        left = max(0, cand_span.start - window)
+        right = min(len(text), cand_span.end + window)
+        window_text = text[left:right]
+
+        # Select spans that intersect window, adjust to window-relative coords
+        window_spans: list[tuple[Span, PIIType]] = []
+        for sp, lab in labeled_spans:
+            if sp.start < right and left < sp.end:
+                rs = max(sp.start, left) - left
+                re = min(sp.end, right) - left
+                # Create a window-relative span
+                window_spans.append((Span(rs, re, window_text[rs:re]), lab))
+
+        red = typed_redact_text(window_text, window_spans)
+        result[idx] = red.redacted_text
     return result

--- a/tests/test_redaction_tokens.py
+++ b/tests/test_redaction_tokens.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from catalog_pii_scanner.embeddings import EmbedModel
+from catalog_pii_scanner.ensemble import Calibrator, Ensemble
+from catalog_pii_scanner.pii_types import PIIType
+from catalog_pii_scanner.redaction import contexts_for_candidates
+from catalog_pii_scanner.rules import propose_candidates
+
+
+def test_contexts_use_bracket_tokens() -> None:
+    text = "Contact John Doe at john.doe@example.com or +1 (415) 555-1234."
+    cands = propose_candidates(text)
+    ctxs = contexts_for_candidates(text, cands, window=64)
+    # Ensure tokens appear and raw values do not
+    any_email = any("[EMAIL]" in v for v in ctxs.values())
+    any_phone = any("[PHONE_NUMBER]" in v for v in ctxs.values())
+    assert any_email, "Expected [EMAIL] token in contexts"
+    assert any_phone, "Expected [PHONE_NUMBER] token in contexts"
+    for v in ctxs.values():
+        assert "john.doe@example.com" not in v
+        assert "+1 (415) 555-1234" not in v
+
+
+def test_contexts_cover_multiple_types() -> None:
+    text = (
+        "Name: Jane Roe, Email: jane.roe@example.org, Phone: 212-555-9876, "
+        "CC: 4111 1111 1111 1111, SSN: 123-45-6789"
+    )
+    cands = propose_candidates(text)
+    ctxs = contexts_for_candidates(text, cands, window=80)
+    joined = "\n".join(ctxs.values())
+    # Expect tokens for various types detected by rules
+    assert "[EMAIL]" in joined
+    assert "[PHONE_NUMBER]" in joined
+    assert "[CREDIT_CARD]" in joined
+    assert "[SSN]" in joined
+    # No raw values must leak
+    assert "jane.roe@example.org" not in joined
+    assert "212-555-9876" not in joined
+    assert "4111 1111 1111 1111" not in joined
+    assert "123-45-6789" not in joined
+
+
+class _CapturingEmbed(EmbedModel):
+    captured: list[str]
+
+    def __init__(self) -> None:  # type: ignore[no-untyped-def]
+        super().__init__()
+        self.captured = []
+
+    def predict_proba(self, texts: list[str]) -> dict[int, dict[PIIType, float]]:  # type: ignore[override]
+        self.captured = list(texts)
+        # Neutral predictions
+        return {i: {t: 0.0 for t in PIIType} for i in range(len(texts))}  # type: ignore[arg-type]
+
+
+def test_no_raw_pii_reaches_embeddings() -> None:
+    text = "Reach me at bob.smith@company.com and 650-555-0000."
+    cands = propose_candidates(text)
+    embed = _CapturingEmbed()
+    ens = Ensemble(embed=embed, calibrator=Calibrator.identity())
+    _ = ens.predict(text, cands)
+    # All inputs sent to embeddings must be tokenized and free of raw PII
+    assert embed.captured, "Embeddings received no inputs"
+    joined = "\n".join(embed.captured)
+    assert "[EMAIL]" in joined and "[PHONE_NUMBER]" in joined
+    assert "bob.smith@company.com" not in joined
+    assert "650-555-0000" not in joined


### PR DESCRIPTION
Introduces bracket token redaction (e.g., [EMAIL]) for PII spans, updates context window generation to use typed tokens, and adds tests to ensure no raw PII values leak into model inputs. This improves safety for embeddings/LLM usage and supports multi-type masking.